### PR TITLE
Update docs

### DIFF
--- a/Version History.md
+++ b/Version History.md
@@ -1,5 +1,7 @@
 # Version History
 
+**Current version:** [v4.x](#4x)
+
 ### 2.x
 
 Version 2 was built by Colin Paxton and later maintained by Lee Stone.
@@ -17,7 +19,7 @@ would introduce several new features.
 ### 4.x
 
 Due to its age Version 2 made use of numerous outdated or deprecated
-features and the process of continuous improvement had produced a file
+features, and the process of continuous improvement had produced a file
 structure that was very difficult to manage and keep updated. The site
 also mixed HTML and PHP making updating the style difficult.
 
@@ -30,8 +32,8 @@ Version 4 also led the move of the server to a VPS, full use of the
 Backstage domain ([bts-crew.com][domain]) and the use of git and GitHub to
 manage version control.
 
-This development is led by [Ben Jones][github-bnjns] and is built on PHP 7,
-MySQL 5.6 and Laravel 6.0 and utilises Bootstrap 3.
+This development is led by [Ben Jones][github-bnjns] and is built on PHP
+7, MySQL 5.6 and Laravel and utilises Bootstrap 3.
 
 ### 5.x
 
@@ -55,6 +57,9 @@ and uses the Vue.js framework, using Bootstrap 4.
 
 Version 5 also uses of Docker images for to simplify the deployment
 process, and will likely move hosting to Bath SU on-premises servers.
+
+**Note:** We aim to move to v5 in the long term; for now we will still
+be developing on v4.
 
 [domain]: https://www.bts-crew.com
 [github-bnjns]: https://github.com/bnjns

--- a/docs/Our Tools.md
+++ b/docs/Our Tools.md
@@ -44,6 +44,8 @@ Some other potentially useful channels are:
   the website.
 * `ops-security`: This is where we talk about anything security related.
   [Snyk](#snyk) also posts notifications of vulnerabilities here.
+* `service-ci`: This is where CircleCI will post any notifications about
+  any CI workflows (eg, if a workflow fails).
 * `service-github`: This is where important notifications from GitHub
   are posted, including new Pull Requests.
 * `service-rss`: This is where any potentially interesting news in the
@@ -78,18 +80,12 @@ lives slightly easier:
 * **Google Drive:** This allows you to see previews of files and folders
   within Slack when a link is posted (as long as you have access to it).
   You can even find and create files right from within Slack.
-* **Google Hangouts:** We use Google Meet (aka Hangouts) for our
-  meetings; using this integration you can create a meet from within
-  Slack.
 * **Giphy:** For those times when an animated GIF perfectly sums up your
   reaction to something.
 * **Bugsnag:** Bugsnag is the application that monitors v4 of the
   website, and instantly reports in Slack when an error occurs so that
   we know that a problem's occurred even before the user can report the
   issue in GitHub.
-
-  > This integration is being deprecated as it is not supported by
-  > Quarkus. v5 of the website will use Sentry.io instead.
 
 As we are on the free plan we can only add a limited number of
 integrations, however if there's something that you think would be
@@ -164,8 +160,8 @@ what the different columns mean.
 ## CircleCI
 
 GitHub Actions is sadly a little limited for some of the complex CI/CD
-workflows needed by the API and SPA. Until it has matured, these two
-repositories use [CircleCI][circleci], a leader in the world of CI/CD.
+workflows needed by the site. Until it has matured, we use
+[CircleCI][circleci], a leader in the world of CI/CD.
 
 As our repositories are Open-Source Software (OSS), CircleCI grants us a
 very large number of credits to use for builds. However, some builds can
@@ -223,21 +219,21 @@ automatically to resolve the issues, if it can.
 Sadly Snyk.io is not linked to the GitHub organisation, so access is
 limited. However, you can request access by asking in Slack.
 
-## Keycloak
+<!--## Keycloak-->
 
-The API and SPA use [Keycloak][keycloak] for authentication and
-authorisation. You do not need to access Keycloak itself to be able to
-use the site, but until we have migrated our existing users over (which
-will happen when v5 nears released) you will need to ask for a user
-account to be created. You can do this in [Slack][slack].
+<!--The API and SPA use [Keycloak][keycloak] for authentication and-->
+<!--authorisation. You do not need to access Keycloak itself to be able to-->
+<!--use the site, but until we have migrated our existing users over (which-->
+<!--will happen when v5 nears released) you will need to ask for a user-->
+<!--account to be created. You can do this in [Slack][slack].-->
 
-## Sentry
+<!--## Sentry-->
 
-Sentry is a cloud-based error monitoring tool used to detect application
-errors in real-time, allowing you to react to issues without needing
-users to report bugs in GitHub.
+<!--Sentry is a cloud-based error monitoring tool used to detect application-->
+<!--errors in real-time, allowing you to react to issues without needing-->
+<!--users to report bugs in GitHub.-->
 
-We haven't yet set up Sentry, but it will be integrated into the API.
+<!--We haven't yet set up Sentry, but it will be integrated into the API.-->
 
 ## One-Time Secret
 
@@ -255,12 +251,12 @@ We use [Google Drive][gdrive] for general admin, planning and storing
 documents, such as logos for the website. Anyone in the team can ask for
 access to the folder, and it is available to all committee members.
 
-## Postman
+<!--## Postman-->
 
-[Postman][postman] is a piece of software used for API development, as
-it allows you to send requests and view the responses without needing to
-link it to a front-end. We currently store our collections in a
-[Google Drive](#google-drive) folder.
+<!--[Postman][postman] is a piece of software used for API development, as-->
+<!--it allows you to send requests and view the responses without needing to-->
+<!--link it to a front-end. We currently store our collections in a-->
+<!--[Google Drive](#google-drive) folder.-->
 
 [slack]: https://bts-website.slack.com
 [slack-notifications]: https://slack.com/intl/en-gb/help/articles/201355156-Guide-to-desktop-notifications

--- a/docs/contributing/Developing.md
+++ b/docs/contributing/Developing.md
@@ -12,35 +12,12 @@
 Before you start developing, please make sure you have the following set
 up on your computer.
 
-> **Note:** While it is possible to use all of these tools and develop
-> both the API and SPA on Windows, it is strongly recommended that you
-> use a Linux VM or the Windows Subsystem for Linux in order to take
-> advantage of the tooling we use to simplify some processes.
+> **Note:** While it is possible to use all of these tools and work on
+> the website on Windows, it is strongly recommended that you use a
+> Linux VM or the Windows Subsystem for Linux in order to take advantage
+> of the tooling we use to simplify some processes.
 
-1. **SDKMAN**
-
-   SDKMAN is a useful utility that makes it easy to install and manage
-   Java SDKs. Follow [these instructions][install-sdkman] to install it.
-   You can then install an SDK with the following command:
-
-   ```sh
-   $ sdk install java <version>
-   ```
-
-   This will install the SDK to `~/.sdkman/candidates/java`.
-
-   You can search for available versions using `sdk search java` and set
-   your default java version using `sdk default java <version>`.
-
-2. **Node.js and Yarn**
-
-   Node.js is needed in order to use and run the SPA; you can install
-   the latest LTS (12.x) [here][install-nodejs].
-
-   You will also need to [install Yarn][install-yarn], which is an
-   improved version of npm, the node package manager.
-
-3. **Docker and Docker Compose**
+1. **Docker and Docker Compose**
 
    In order to run any auxiliary services (eg, the SMTP server and
    database) you will need to have [Docker installed][install-docker],
@@ -59,11 +36,10 @@ up on your computer.
    * [Docker Compose CLI][docker-docs-compose-cli]
    * [Docker Compose Files][docker-docs-compose-file]
 
-4. **IDEs**
+2. **IDEs**
 
    At the heart of good development is a good IDE (Integrated
-   Development Environment). There is a lot of choice for both the API
-   and SPA but the recommended IDEs are [IntelliJ IDEA][intellij-idea]
+   Development Environment). There is but the recommended IDEs are [IntelliJ IDEA][intellij-idea]
    and [Webstorm][intellij-webstorm] by JetBrains. Students are able to
    get their entire suite for free if you provide proof of registration.
 
@@ -74,20 +50,20 @@ up on your computer.
    help with any testing and to backup or restore data. Fortunately,
    JetBrains also make an IDE for this - [DataGrip][intellij-datagrip].
 
-5. **jq** (a tool used for JSON processing)
+3. **jq** (a tool used for JSON processing)
 
    * On macOS, if you have [homebrew][homebrew] installed just run `brew
      install jq`
    * On Linux, it's likely `jq` is available from your package manager
    * If all else fails, you can [download it][jq]
 
-6. Ensure you have an SSH key added to GitHub
+4.  Ensure you have an SSH key added to GitHub
 
    > You can follow [this guide][ssh-create] to create an SSH key if you
    > do not already have one, and [this guide][ssh-github] to add it to
    > your GitHub account.
 
-7. Ensure you have a GPG key for signing commits
+5. Ensure you have a GPG key for signing commits
    * Follow [this guide][gpg-create] to create a new GPG key. Make sure
      it is RSA 4096.
    * Follow [this guide][gpg-github] to add it to GitHub
@@ -104,9 +80,12 @@ up on your computer.
      $ git config --global commit.gpgsign true
      ```
 
-8. Make sure you have an account in our nonprod
-   [Keycloak](../Our%20Tools.md#keycloak) realm. You can ask in Slack if
-   you're not sure.
+<!--6. Make sure you have an account in our nonprod-->
+<!--   [Keycloak](../Our%20Tools.md#keycloak) realm. You can ask in Slack if-->
+<!--   you're not sure.-->
+
+> **Note:** Each individual repository will also contain the necessary
+> pre-requisites specific to that repository.
 
 ## Getting started
 
@@ -121,7 +100,7 @@ $ git clone git@github.com:backstage-technical-services/website-development.git 
 ```
 
 The [included readme][development-readme] will contain any more
-information on how to get the API and SPA downloaded and set up.
+information on how to get the rest of the website downloaded and set up.
 
 ## Questions or need help?
 

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,9 @@
 The Hub is the go-to place for any information about the website of
 Backstage Technical Services.
 
-As we are moving to an API and SPA, it made sense to move issues and
-documentation out of the Laravel site's repository and into a central
-area.
+As we are moving to an API and SPA in the long term, it made sense to
+move issues and documentation out of the Laravel site's repository and
+into a central area.
 
 **Useful Links**
 


### PR DESCRIPTION
These are a few small tweaks to our docs:

* Tried to make it clearer that `v4` is the current version, and `v5` is the long-term aim.
* Removed some of the tools that were v5 specific
* Tried to make the section on getting started a bit more generic, so that they apply equally to v4 and v5. I'll move the sections on SKDMAN and Node.js/yarn to the v5 API and SPA respectively.